### PR TITLE
draft implementation of moving the object with the mouse

### DIFF
--- a/src/GameObjects/SimpleObject.h
+++ b/src/GameObjects/SimpleObject.h
@@ -68,5 +68,6 @@ public:
     virtual string getObjectName() = 0;
     virtual void onCollision() = 0;
     virtual void setDefaultZ() = 0;
+    virtual void setPosition(ofVec3f position) = 0;
    
 };

--- a/src/ScenarioEditor/ScenarioEditor.cpp
+++ b/src/ScenarioEditor/ScenarioEditor.cpp
@@ -18,6 +18,9 @@ void ScenarioEditor::setup(chinoWorld &world, Scenario &scenario){
 	this->world->enableGrabbing(-1);
 	ofAddListener(world.MOUSE_PICK_EVENT, this, &ScenarioEditor::onMousePick);
     
+    ofRegisterMouseEvents(this);
+    
+    selectedObject = NULL;
 }
 
 //--------------------------------------------------------------
@@ -62,17 +65,52 @@ void ScenarioEditor::keyReleased(int key){
 
 //--------------------------------------------------------------
 void ScenarioEditor::onMousePick( ofxBulletMousePickEvent &e ) {
+    
+    selectedObject = NULL;
 	
     //    cout << "ScenarioEditor::onMousePick : selected a body!!!" << endl;
     for(int i = 0; i < scenario->ScenarioObjects.size(); i++) {
 		ofxBulletBaseShape *baseShape;
         baseShape = scenario->ScenarioObjects[i]->getBulletBaseShape();
         if(*baseShape == e) {
+            
+            selectedObject = scenario->ScenarioObjects[i];
+            
+            //selectedObject
             ofLogVerbose("EditorVerbose") << "ScenarioEditor::onMousePick : selected a " << scenario->ScenarioObjects[i]->getObjectName() << endl;
+            
 			//mousePickPos = e.pickPosWorld;
 			break;
 		}
 	}
+    
+}
+
+//--------------------------------------------------------
+void ScenarioEditor::mouseDragged(ofMouseEventArgs &args){
+    ofVec3f newPos;
+    if (selectedObject != NULL){
+        
+        newPos = selectedObject->position;
+        newPos.x = newPos.x + (args.x/1000);
+        newPos.y = newPos.y + (args.y/1000);
+        selectedObject -> position = newPos;
+        selectedObject -> setPosition(newPos);
+    }
+}
+
+//--------------------------------------------------------
+void ScenarioEditor::mouseMoved(ofMouseEventArgs &args){
+    
+}
+
+//--------------------------------------------------------
+void ScenarioEditor::mousePressed(ofMouseEventArgs &args){
+    
+}
+
+//--------------------------------------------------------
+void ScenarioEditor::mouseReleased(ofMouseEventArgs &args){
     
 }
 

--- a/src/ScenarioEditor/ScenarioEditor.h
+++ b/src/ScenarioEditor/ScenarioEditor.h
@@ -35,5 +35,12 @@ public:
     Scenario *                scenario;
 	
 	bool bEscenarioEditorMode;
+    
+    SimpleObject *selectedObject; /* current selected object, NULL if no object selected */
+    void mouseDragged(ofMouseEventArgs &args);
+    void mouseMoved(ofMouseEventArgs &args);
+    void mousePressed(ofMouseEventArgs &args);
+    void mouseReleased(ofMouseEventArgs &args);
+    
     void addObject(SimpleObject::shapeType type);
 };


### PR DESCRIPTION
In the ScenarioEditor the following code was added.

```
//--------------------------------------------------------
void ScenarioEditor::mouseDragged(ofMouseEventArgs &args){
    ofVec3f newPos;
    if (selectedObject != NULL){

        newPos = selectedObject->position;
        newPos.x = newPos.x + (args.x/1000);
        newPos.y = newPos.y + (args.y/1000);
        selectedObject -> position = newPos;
        selectedObject -> setPosition(newPos);
    }
}
```

For the moment the new position is not calculated well because the object moves only in one direction.
The position is changed by calling SimpleObject::SetPosition that created a new rigid body.
We should see what is the impact of this

```
void Hammer::setPosition(ofVec3f position){

    btTransform transform;
    btRigidBody* rigidBody = body.getRigidBody();
    rigidBody->getMotionState()->getWorldTransform( transform );
    btVector3 origin;
    origin.setX(position.x);
    origin.setY(position.y);
    origin.setZ(position.z);
    transform.setOrigin(origin);
    rigidBody->getMotionState()->setWorldTransform( transform );

}
```
